### PR TITLE
fix(backend): Refine docker-compose build configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
-version: '3.8'
-
 services:
   backend:
-    build: ./apps/backend
+    build:
+      context: ./apps/backend
+      dockerfile: Dockerfile
     ports:
       - "8000:8000"
     volumes:


### PR DESCRIPTION
- Removes the obsolete `version` attribute from the docker-compose file.
- Specifies the build context and Dockerfile explicitly to prevent potential build target errors on different Docker versions.